### PR TITLE
Add `paths` option to `case-sensitive` and `no-unresolved`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ An [eslint](https://github.com/eslint/eslint) plugin that ...
 
 Verifies that `require("…")`, `require.resolve(…)`, `import "…"` and `export … from "…"` ids match the case that is reported by a directory listing.
 
+```json
+{
+  "plugins": [
+    "dependencies"
+  ],
+  "rules": {
+    "dependencies/case-sensitive": [1, {"paths": ["custom-path-to-search-for-modules"]}]
+  }
+}
+```
+
 ### `dependencies/no-cycles`
 
 Prevents cyclic references between modules. It resolves `require("…")`, `import "…"` and `export … from "…"` references to internal modules (i.e. not `node_modules`), to determine whether there is a cycle. If you're using a custom parser, the rule will use that to parse the dependencies. The rule takes a `skip` array of strings, that will be treated as regexps to skip checking files.
@@ -57,7 +68,7 @@ Checks that `require("…")`, `require.resolve(…)`, `import "…"` and `export
     "dependencies"
   ],
   "rules": {
-    "dependencies/no-unresolved": [1, {"ignore": ["atom"]}]
+    "dependencies/no-unresolved": [1, {"ignore": ["atom"], "paths": ["custom-path-to-search-for-modules"]}]
   }
 }
 ```

--- a/case-sensitive.js
+++ b/case-sensitive.js
@@ -52,9 +52,15 @@ module.exports = function(context) {
     extensions: ['.js', '.json', '.node'],
   };
 
+  if (context.options[0] && context.options[0].paths) {
+    resolveOpts.paths = context.options[0].paths.map(function(single_path) {
+      return path.resolve(single_path);
+    });
+  }
+
   function validate(node) {
     var id = helpers.getModuleId(node);
-    var resolved = helpers.resolveSync(id, resolveOpts);
+    var resolved = helpers.resolveSync(id, resolveOpts, context);
     if (!resolved || resolve.isCore(resolved)) return;
     var prefix = commondir([target, resolved]);
     pathSteps(resolved)
@@ -133,4 +139,11 @@ module.exports = function(context) {
   };
 };
 
-module.exports.schema = [];
+module.exports.schema = {
+  paths: {
+    type: 'array',
+    items: {
+      type: 'string',
+    },
+  },
+};

--- a/no-unresolved.js
+++ b/no-unresolved.js
@@ -13,6 +13,12 @@ module.exports = function(context) {
     extensions: ['.js', '.json', '.node'],
   };
 
+  if (context.options[0] && context.options[0].paths) {
+    resolveOpts.paths = context.options[0].paths.map(function(single_path) {
+      return path.resolve(single_path);
+    });
+  }
+
   function validate(node) {
     var id = helpers.getModuleId(node);
     if (ignore && ignore.indexOf(id) !== -1) return;
@@ -53,6 +59,12 @@ module.exports = function(context) {
 
 module.exports.schema = {
   ignore: {
+    type: 'array',
+    items: {
+      type: 'string',
+    },
+  },
+  paths: {
     type: 'array',
     items: {
       type: 'string',

--- a/test/case-sensitive-test.js
+++ b/test/case-sensitive-test.js
@@ -39,6 +39,13 @@ ruleTester.run('case-sensitive', require.resolve('../case-sensitive'), {
       filename: __filename,
       code: 'require(foo)',
     },
+    // custom path
+    {
+      filename: __filename,
+      code: 'require("foo")',
+      options: [{ paths: ["test/custom-path"] }],
+    },
+
     // require.resolve(…);
     {
       filename: __filename,
@@ -167,6 +174,18 @@ ruleTester.run('case-sensitive', require.resolve('../case-sensitive'), {
       code: 'require("resolve/Index")',
       errors: [
         'Case mismatch in "Index", expected "index".',
+      ],
+    },
+
+    //
+    // custom path
+    //
+    {
+      filename: __filename,
+      code: 'require("Foo")',
+      options: [{ paths: ["test/custom-path"] }],
+      errors: [
+        'Case mismatch in "Foo", expected "foo".',
       ],
     },
 

--- a/test/no-unresolved-test.js
+++ b/test/no-unresolved-test.js
@@ -46,6 +46,12 @@ ruleTester.run('no-unresolved', require.resolve('../no-unresolved'), {
       code: 'require("non-existing-package")',
       options: [{ignore: ['non-existing-package']}],
     },
+    // test custom path resolution
+    {
+      filename: __filename,
+      code: 'require("foo")',
+      options: [{paths: ['test/custom-path']}],
+    },
 
     //
     // require.resolve, import, export
@@ -116,6 +122,18 @@ ruleTester.run('no-unresolved', require.resolve('../no-unresolved'), {
         },
       ],
     },
+    // test custom path resolution
+    {
+      filename: __filename,
+      code: 'require("foo")',
+      errors: [
+        {
+          type: 'Literal',
+          message: '"foo" does not exist.',
+        },
+      ],
+    },
+
 
 
     //


### PR DESCRIPTION
Fixes https://github.com/zertosh/eslint-plugin-dependencies/issues/2.

Rather than use NODE_PATH—since that can be difficult to configure correctly, at least it is in my editor's version of `eslint`—I thought an optional array of paths was better.

I did not add to the `no-cycles` or `require-json-ext` rules, as I don't use those.

Happy to change as you see fit!