### PR TITLE
Invalidate case-sensitive and no-cycles caches after process.nextTick

### DIFF
--- a/case-sensitive.js
+++ b/case-sensitive.js
@@ -9,16 +9,18 @@ var helpers = require('./_helpers');
 
 var nodeExts = /\.(js|json|node)$/;
 
-var _readdirCache = Object.create(null);
+var _readdirCache = new helpers.TickCache();
 function readdirSync(dirname) {
-  if (!(dirname in _readdirCache)) {
+  var cached = _readdirCache.get(dirname);
+  if (cached === undefined) {
     try {
-      _readdirCache[dirname] = fs.readdirSync(dirname);
+      cached = fs.readdirSync(dirname);
     } catch (err) {
-      _readdirCache[dirname] = null;
+      cached = null;
     }
+    _readdirCache.set(dirname, cached);
   }
-  return _readdirCache[dirname];
+  return cached;
 }
 
 // turns "/a/b/c.js" into ["/a", "/a/b", "/a/b/c.js"]

--- a/no-cycles.js
+++ b/no-cycles.js
@@ -81,10 +81,13 @@ function relativizeTrace(trace, basedir) {
   return out;
 }
 
-var depsCache = new helpers.StorageObject();
+var depsCache = new helpers.TickCache();
 function getDeps(filename, src, ast, context) {
-  if (depsCache[filename]) return depsCache[filename];
-  var found = depsCache[filename] = [];
+  var cached = depsCache.get(filename);
+  if (cached) return cached;
+
+  var found = [];
+  depsCache.set(filename, found);
 
   if (skipExts.test(filename)) return found;
 


### PR DESCRIPTION
I created a generic `TickCache` that clears itself after every tick (once used). It introduces a slight overhead but nothing too significant, I hope. (Or I can just copy+paste the old stuff if you prefer).