### PR TITLE
no-cycles: "types" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,15 @@ Verifies that `require("…")`, `require.resolve(…)`, `import "…"` and `expo
 
 Prevents cyclic references between modules. It resolves `require("…")`, `import "…"` and `export … from "…"` references to internal modules (i.e. not `node_modules`), to determine whether there is a cycle. If you're using a custom parser, the rule will use that to parse the dependencies. The rule takes a `skip` array of strings, that will be treated as regexps to skip checking files.
 
+Additionally, with the `types` option enabled, you can detect and prevent `import type` cycles as well. This can be helpful, since the [Flow checker](https://flow.org) can exhibit unexpected behavior with such cycles.
+
 ```json
 {
   "plugins": [
     "dependencies"
   ],
   "rules": {
-    "dependencies/no-cyles": [1, {"skip": ["/spec/", "/vendor/"]}]
+    "dependencies/no-cyles": [1, {"skip": ["/spec/", "/vendor/"], "types": true}]
   }
 }
 ```

--- a/test/cycles-types-multi-direct/a.js
+++ b/test/cycles-types-multi-direct/a.js
@@ -1,0 +1,4 @@
+// a => b => c => a
+// a ======> c => a
+import type { B } from './b';
+import type { C } from './c';

--- a/test/cycles-types-multi-direct/b.js
+++ b/test/cycles-types-multi-direct/b.js
@@ -1,0 +1,1 @@
+import type { C } from './c';

--- a/test/cycles-types-multi-direct/c.js
+++ b/test/cycles-types-multi-direct/c.js
@@ -1,0 +1,1 @@
+import type { A } from './a';

--- a/test/no-cycles-test.js
+++ b/test/no-cycles-test.js
@@ -51,6 +51,20 @@ ruleTester.run('no-cycles', require.resolve('../no-cycles'), {
       ],
     },
     {
+      // types-multi-direct
+      // a => b => c => a
+      // a ======> c => a
+      filename: path.join(__dirname, 'cycles-types-multi-direct/a.js'),
+      parser: 'babel-eslint',
+      parserOptions: {sourceType: 'module'},
+      code: fs.readFileSync(path.join(__dirname, 'cycles-types-multi-direct/a.js'), 'utf8'),
+      options: [{types: true}],
+      errors: [
+        'Cycle in b.js => c.js.',
+        'Cycle in c.js.',
+      ],
+    },
+    {
       // multi-part-direct
       // a => b => c => a
       //      b ======> a


### PR DESCRIPTION
"import type" cycles lead to bizarre behavior with the Flow checker (usually the imported types behave as "any" with no warnings).

This adds the ability to detect such cycles, as a "types" option for this plugin.

I hope I did this right, since I've never worked with the innards of eslint plugins before. If any have any comments or corrections on this PR, I'd be happy to cooperate. And hey — there are tests :) 